### PR TITLE
Allow reading settings from configuration file

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -625,7 +625,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "ce580caac76bdd8338e709ff505a06f43068ce2b4d0c68d4d92b3775c6a90250"
+content-hash = "bb073da964fa73aa3e6fa2fd2a1974c91c8a3b77eea4a74033b45c6b99523d20"
 python-versions = "^3.6"
 
 [metadata.files]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ python = "^3.6"
 click = "^7.1.1"
 black = {version = "^19.10b0", allow-prereleases = true}
 snakemake = "^5.14.0"
+toml = "^0.10.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"

--- a/snakefmt/exceptions.py
+++ b/snakefmt/exceptions.py
@@ -36,3 +36,11 @@ class TooManyParameters(Exception):
 
 class UnsupportedSyntax(Exception):
     pass
+
+
+class InvalidBlackConfiguration(Exception):
+    pass
+
+
+class MalformattedToml(Exception):
+    pass

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,9 +1,11 @@
 from io import StringIO
-from snakefmt.parser.parser import Snakefile
+
+from snakefmt import DEFAULT_LINE_LENGTH
 from snakefmt.formatter import Formatter
+from snakefmt.parser.parser import Snakefile
 
 
-def setup_formatter(snake: str):
+def setup_formatter(snake: str, line_length: int = DEFAULT_LINE_LENGTH):
     stream = StringIO(snake)
     smk = Snakefile(stream)
-    return Formatter(smk)
+    return Formatter(smk, line_length=line_length)

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -185,6 +185,40 @@ class TestPythonFormatting:
         formatter = setup_formatter(snakecode)
         assert formatter.get_formatted() == snakecode
 
+    def test_line_wrapped_python_code_outside_rule(self):
+        content = "list_of_lots_of_things = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]\ninclude: snakefile"
+        line_length = 30
+        formatter = setup_formatter(content, line_length=line_length)
+
+        actual = formatter.get_formatted()
+        expected = (
+            "list_of_lots_of_things = [\n"
+            f"{TAB}1,\n{TAB}2,\n{TAB}3,\n{TAB}4,\n{TAB}5,\n{TAB}6,\n{TAB}7,\n"
+            f"{TAB}8,\n{TAB}9,\n{TAB}10,\n"
+            "]\n"
+            "include: snakefile\n"
+        )
+
+        assert actual == expected
+
+    @pytest.mark.xfail(reason="Indenting out by one for elements in list")
+    def test_line_wrapped_python_code_inside_rule(self):
+        content = f"rule a:\n{TAB}input:\n{TAB*2}list_of_lots_of_things = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]"
+        line_length = 30
+        formatter = setup_formatter(content, line_length=line_length)
+
+        actual = formatter.get_formatted()
+        expected = (
+            "rule a:\n"
+            f"{TAB*1}input:\n"
+            f"{TAB*2}list_of_lots_of_things=[\n"
+            f"{TAB*3}1,\n{TAB*3}2,\n{TAB*3}3,\n{TAB*3}4,\n{TAB*3}5,\n"
+            f"{TAB*3}6,\n{TAB*3}7,\n{TAB*3}8,\n{TAB*3}9,\n{TAB*3}10,\n"
+            f"{TAB*2}],\n"
+        )
+
+        assert actual == expected
+
 
 class TestSimpleParamFormatting:
     def test_singleParamKeyword_staysOnSameLine(self):

--- a/tests/test_snakefmt.py
+++ b/tests/test_snakefmt.py
@@ -105,6 +105,7 @@ list_of_lots_of_things = [
 
         assert actual.output == expected_output
 
+    @pytest.mark.xfail(reason="Indenting out by one for elements in list")
     def test_config_adherence_for_code_inside_rules(self, cli_runner, tmp_path):
         stdin = f"rule a:\n{TAB}input:\n{TAB*2}list_of_lots_of_things = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]"
         line_length = 30
@@ -116,22 +117,14 @@ list_of_lots_of_things = [
 
         assert actual.exit_code == 0
 
-        expected_output = f"""rule a:
-{TAB*1}input:
-{TAB*2}list_of_lots_of_things=[
-{TAB*3}1,
-{TAB*3}2,
-{TAB*3}3,
-{TAB*3}4,
-{TAB*3}5,
-{TAB*3}6,
-{TAB*3}7,
-{TAB*3}8,
-{TAB*3}9,
-{TAB*3}10,
-{TAB*2}],
-        
-"""
+        expected_output = (
+            "rule a:\n"
+            f"{TAB*1}input:\n"
+            f"{TAB*2}list_of_lots_of_things=[\n"
+            f"{TAB*3}1,\n{TAB*3}2,\n{TAB*3}3,\n{TAB*3}4,\n{TAB*3}5,\n"
+            f"{TAB*3}6,\n{TAB*3}7,\n{TAB*3}8,\n{TAB*3}9,\n{TAB*3}10,\n"
+            f"{TAB*2}],\n"
+        )
 
         assert actual.output == expected_output
 

--- a/tests/test_snakefmt.py
+++ b/tests/test_snakefmt.py
@@ -1,9 +1,11 @@
+import os
 import re
 import tempfile
 from collections import Counter
 from pathlib import Path
 from unittest import mock
 
+import click
 import pytest
 from click.testing import CliRunner
 
@@ -11,6 +13,7 @@ from snakefmt.snakefmt import (
     construct_regex,
     main,
     get_snakefiles_in_dir,
+    read_snakefmt_defaults_from_pyproject_toml,
 )
 
 
@@ -58,6 +61,170 @@ class TestCLI:
         actual = cli_runner.invoke(main, params)
         assert actual.exit_code != 0
         assert "Invalid regular expression" in str(actual.exception)
+
+
+class TestReadSnakefmtDefaultsFromPyprojectToml:
+    def test_no_value_passed_and_no_pyproject_changes_nothing(self, tmpdir):
+        os.chdir(tmpdir)
+        default_map = dict()
+        ctx = click.Context(click.Command("snakefmt"), default_map=default_map)
+        param = mock.MagicMock()
+        value = None
+
+        return_val = read_snakefmt_defaults_from_pyproject_toml(ctx, param, value)
+
+        assert return_val is None
+
+        actual_default_map = ctx.default_map
+        expected_default_map = dict()
+
+        assert actual_default_map == expected_default_map
+
+    def test_no_value_passed_and_pyproject_present_but_empty_changes_nothing_returns_pyproject_path(
+        self, tmpdir
+    ):
+        os.chdir(tmpdir)
+        pyproject = Path("pyproject.toml")
+        pyproject.touch()
+        default_map = dict()
+        ctx = click.Context(click.Command("snakefmt"), default_map=default_map)
+        param = mock.MagicMock()
+        value = None
+
+        actual_config_path = read_snakefmt_defaults_from_pyproject_toml(
+            ctx, param, value
+        )
+        expected_config_path = None
+
+        assert actual_config_path == expected_config_path
+
+        actual_default_map = ctx.default_map
+        expected_default_map = dict()
+
+        assert actual_default_map == expected_default_map
+
+    def test_no_value_passed_and_pyproject_present_changes_default_line_length(
+        self, tmpdir
+    ):
+        os.chdir(tmpdir)
+        pyproject = Path("pyproject.toml")
+        pyproject.write_text("[tool.snakefmt]\nline_length = 4")
+        default_map = dict(line_length=88)
+        ctx = click.Context(click.Command("snakefmt"), default_map=default_map)
+        param = mock.MagicMock()
+        value = None
+
+        actual_config_path = read_snakefmt_defaults_from_pyproject_toml(
+            ctx, param, value
+        )
+        expected_config_path = str(pyproject)
+
+        assert actual_config_path == expected_config_path
+
+        actual_default_map = ctx.default_map
+        expected_default_map = dict(line_length=4)
+
+        assert actual_default_map == expected_default_map
+
+    def test_no_value_passed_and_pyproject_present_unknown_param_adds_to_default_map(
+        self, tmpdir
+    ):
+        os.chdir(tmpdir)
+        pyproject = Path("pyproject.toml")
+        pyproject.write_text("[tool.snakefmt]\nfoo = true")
+        default_map = dict()
+        ctx = click.Context(click.Command("snakefmt"), default_map=default_map)
+        param = mock.MagicMock()
+        value = None
+
+        actual_config_path = read_snakefmt_defaults_from_pyproject_toml(
+            ctx, param, value
+        )
+        expected_config_path = str(pyproject)
+
+        assert actual_config_path == expected_config_path
+
+        actual_default_map = ctx.default_map
+        expected_default_map = dict(foo=True)
+
+        assert actual_default_map == expected_default_map
+
+    def test_value_passed_reads_from_path(self, tmpdir):
+        os.chdir(tmpdir)
+        pyproject = Path("snakefmt.toml")
+        pyproject.write_text("[tool.snakefmt]\nfoo = true")
+        default_map = dict()
+        ctx = click.Context(click.Command("snakefmt"), default_map=default_map)
+        param = mock.MagicMock()
+        value = str(pyproject)
+
+        actual_config_path = read_snakefmt_defaults_from_pyproject_toml(
+            ctx, param, value
+        )
+        expected_config_path = str(pyproject)
+
+        assert actual_config_path == expected_config_path
+
+        actual_default_map = ctx.default_map
+        expected_default_map = dict(foo=True)
+
+        assert actual_default_map == expected_default_map
+
+    def test_value_passed_but_default_map_is_empty_still_updates_defaults(self, tmpdir):
+        os.chdir(tmpdir)
+        pyproject = Path("snakefmt.toml")
+        pyproject.write_text("[tool.snakefmt]\nfoo = true")
+        default_map = None
+        ctx = click.Context(click.Command("snakefmt"), default_map=default_map)
+        param = mock.MagicMock()
+        value = str(pyproject)
+
+        actual_config_path = read_snakefmt_defaults_from_pyproject_toml(
+            ctx, param, value
+        )
+        expected_config_path = str(pyproject)
+
+        assert actual_config_path == expected_config_path
+
+        actual_default_map = ctx.default_map
+        expected_default_map = dict(foo=True)
+
+        assert actual_default_map == expected_default_map
+
+    def test_value_passed_in_overrides_pyproject(self, tmpdir):
+        os.chdir(tmpdir)
+        snakefmt_config = Path("snakefmt.toml")
+        snakefmt_config.write_text("[tool.snakefmt]\nfoo = true")
+        pyproject = Path("pyproject.toml")
+        pyproject.write_text("[tool.snakefmt]\n\nfoo = false\nline_length = 90")
+        default_map = dict()
+        ctx = click.Context(click.Command("snakefmt"), default_map=default_map)
+        param = mock.MagicMock()
+        value = str(snakefmt_config)
+
+        actual_config_path = read_snakefmt_defaults_from_pyproject_toml(
+            ctx, param, value
+        )
+        expected_config_path = str(snakefmt_config)
+
+        assert actual_config_path == expected_config_path
+
+        actual_default_map = ctx.default_map
+        expected_default_map = dict(foo=True)
+
+        assert actual_default_map == expected_default_map
+
+    def test_malformatted_toml_raises_error(self, tmpdir):
+        os.chdir(tmpdir)
+        pyproject = Path("pyproject.toml")
+        pyproject.write_text("foo:bar,baz\n{dict}\&&&&")
+        default_map = dict()
+        ctx = click.Context(click.Command("snakefmt"), default_map=default_map)
+        param = mock.MagicMock()
+        value = None
+
+        with pytest.raises(click.FileError):
+            read_snakefmt_defaults_from_pyproject_toml(ctx, param, value)
 
 
 class TestConstructRegex:


### PR DESCRIPTION
This PR closes #3 

### Added:
- Read `snakefmt` setting from (TOML) file passed to `--config`. If `--config` is not given, the current directory is searched for `pyproject.toml` and attempts to read settings from that [#3].
- In a similar manner to the previous, `black` settings are also read from whichever file was used to get `snakefmt` settings. `snakefmt` settings always take precedent [#3].
- Allowed formatting Snakefile from stdin [#4]

### Changed:
- Increased minimum versions required for `snakemake` and `click` due to failing tests on older versions.

In addition, this PR contains one failing test: https://github.com/mbhall88/snakefmt/blob/f9c970870060b43d612f1db2fbaed2edd7df9469/tests/test_snakefmt.py#L108-L136

See #29 for more details